### PR TITLE
Bytter sufix pa fasit rest resource fra Api til RestService

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn set_up_applicationinstance(
     application_name: &String,
     zone: &Zone,
     env: &str) -> String {
-    let resource_name = format!("{}Api", application_name);
+    let resource_name = format!("{}RestService", application_name);
     let url = zone.application_url_for(application_name, env);
 
     let resource_id = get_or_create_resource(&fasit_user, &resource_name, &url, env);


### PR DESCRIPTION
Gjor dette for a ikke komme i konflikt med rest service for api-gw som api-management setter opp. Resolves #3.