### PR TITLE
byttet til team namespaces

### DIFF
--- a/job.yaml
+++ b/job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: restgw-iac
-  namespace: syfocron
+  namespace: teamsykefravr
 spec:
   template:
     spec:


### PR DESCRIPTION
vi har lansert noe som heter team namespaces, som betyr at man ikke trenger egne namespaces for cronjobs/jobs. Jeg driver i den sammenhengen å faser ut de gamle naisjobs-namespaces. Eneste forskjellen er navnet på namespacet (og at man har flere muligheter i team namespaces).